### PR TITLE
Fixed help option -bucket string

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func parseFlags() {
 	payloadsMinArg := flag.Int("payloads-min", 1, "The minimum object size to test, with 1 = 1 KB, and every increment is a double of the previous value.")
 	payloadsMaxArg := flag.Int("payloads-max", 10, "The maximum object size to test, with 1 = 1 KB, and every increment is a double of the previous value.")
 	samplesArg := flag.Int("samples", 1000, "The number of samples to collect for each test of a single object size and thread count.")
-	bucketNameArg := flag.String("bucket-name", "", "Cleans up all the S3 artifacts used by the benchmarks.")
+	bucketNameArg := flag.String("bucket-name", "", "The bucket name that will be created for this test.")
 	regionArg := flag.String("region", "", "Sets the AWS region to use for the S3 bucket. Only applies if the bucket doesn't already exist.")
 	endpointArg := flag.String("endpoint", "", "Sets the S3 endpoint to use. Only applies to non-AWS, S3-compatible stores.")
 	fullArg := flag.Bool("full", false, "Runs the full exhaustive test, and overrides the threads and payload arguments.")


### PR DESCRIPTION
Currently the first help entry reports:

Using s3-benchmark:
  --bucket-name string
    	Cleans up all S3 artifacts used by benchmarks.